### PR TITLE
Remove outputDirectory config causing 404 errors

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "outputDirectory": ".next",
   "crons": [
     {
       "path": "/api/cron/daily-sync",


### PR DESCRIPTION
- Next.js App Router handles output directory automatically
- outputDirectory: '.next' was causing deployment routing issues
- Revert to minimal vercel.json with just cron configuration